### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,5 +1,6 @@
 {
   "name" : "Pod::EOD",
+  "license" : "MIT",
   "source-url" : "https://github.com/hoelzro/p6-pod-eod.git",
   "perl" : "6.c",
   "provides" : {


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license